### PR TITLE
Fix deleting installation by name

### DIFF
--- a/kerl
+++ b/kerl
@@ -301,7 +301,7 @@ is_valid_installation()
             name=$(echo "$l" | cut -d " " -f 1)
             path=$(echo "$l" | cut -d " " -f 2)
             if [ "$name" = "$1" -o "$path" = "$1" ]; then
-                if [ -f "$1"/activate ]; then
+                if [ -f "$path"/activate ]; then
                     return 0
                 fi
             fi


### PR DESCRIPTION
`kerl delete installation` allows deleting by name or path.
Problem is, if you provide the name it tries to check for a
file `"$name"/activate` instead of using the path, and fails.